### PR TITLE
수동 입찰 기능 개발

### DIFF
--- a/src/main/java/com/mine/application/bid/BidFacade.java
+++ b/src/main/java/com/mine/application/bid/BidFacade.java
@@ -1,0 +1,18 @@
+package com.mine.application.bid;
+
+import com.mine.domain.bid.BidCommand;
+import com.mine.domain.bid.BidInfo;
+import com.mine.domain.bid.BidService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class BidFacade {
+
+    private final BidService bidService;
+
+    public BidInfo bid(BidCommand command) {
+        return bidService.bid(command);
+    }
+}

--- a/src/main/java/com/mine/common/exception/AuctionAlreadyClosedException.java
+++ b/src/main/java/com/mine/common/exception/AuctionAlreadyClosedException.java
@@ -1,0 +1,13 @@
+package com.mine.common.exception;
+
+import com.mine.common.response.ErrorCode;
+
+public class AuctionAlreadyClosedException extends BaseException {
+    public AuctionAlreadyClosedException() {
+        super(ErrorCode.COMMON_AUCTION_ALREADY_CLOSED);
+    }
+
+    public AuctionAlreadyClosedException(String message) {
+        super(message, ErrorCode.COMMON_AUCTION_ALREADY_CLOSED);
+    }
+}

--- a/src/main/java/com/mine/common/exception/HighestBidPriceUpdateException.java
+++ b/src/main/java/com/mine/common/exception/HighestBidPriceUpdateException.java
@@ -1,0 +1,14 @@
+package com.mine.common.exception;
+
+import com.mine.common.response.ErrorCode;
+
+public class HighestBidPriceUpdateException extends BaseException {
+
+    public HighestBidPriceUpdateException() {
+        super(ErrorCode.COMMON_HIGHEST_BID_NOT_UPDATED);
+    }
+
+    public HighestBidPriceUpdateException(String message) {
+        super(message, ErrorCode.COMMON_HIGHEST_BID_NOT_UPDATED);
+    }
+}

--- a/src/main/java/com/mine/common/response/CommonControllerAdvice.java
+++ b/src/main/java/com/mine/common/response/CommonControllerAdvice.java
@@ -10,7 +10,6 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
-
 @RestControllerAdvice
 @Slf4j
 public class CommonControllerAdvice {

--- a/src/main/java/com/mine/common/response/ErrorCode.java
+++ b/src/main/java/com/mine/common/response/ErrorCode.java
@@ -12,7 +12,8 @@ public enum ErrorCode {
     COMMON_ENTITY_NOT_FOUND("존재하지 않는 엔티티입니다."),
     COMMON_ILLEGAL_STATUS("잘못된 상태 값입니다."),
     COMMON_ENTITY_EXISTS("이미 존재하는 엔티티입니다."),
-    COMMON_HIGHEST_BID_NOT_UPDATED("입찰에 실패했습니다. 현재 최고 입찰가보다 높은 입찰가로 다시 시도해주세요.");
+    COMMON_HIGHEST_BID_NOT_UPDATED("입찰에 실패했습니다. 현재 최고 입찰가보다 높은 입찰가로 다시 시도해주세요."),
+    COMMON_AUCTION_ALREADY_CLOSED("이미 마감된 경매입니다. 더 이상 입찰할 수 없습니다.");
 
     private final String errorMessage;
 

--- a/src/main/java/com/mine/common/response/ErrorCode.java
+++ b/src/main/java/com/mine/common/response/ErrorCode.java
@@ -11,7 +11,8 @@ public enum ErrorCode {
     COMMON_INVALID_PARAMETER("요청한 값이 올바르지 않습니다."),
     COMMON_ENTITY_NOT_FOUND("존재하지 않는 엔티티입니다."),
     COMMON_ILLEGAL_STATUS("잘못된 상태 값입니다."),
-    COMMON_ENTITY_EXISTS("이미 존재하는 엔티티입니다.");
+    COMMON_ENTITY_EXISTS("이미 존재하는 엔티티입니다."),
+    COMMON_HIGHEST_BID_NOT_UPDATED("입찰에 실패했습니다. 현재 최고 입찰가보다 높은 입찰가로 다시 시도해주세요.");
 
     private final String errorMessage;
 

--- a/src/main/java/com/mine/domain/auction/AuctionCommand.java
+++ b/src/main/java/com/mine/domain/auction/AuctionCommand.java
@@ -1,5 +1,6 @@
 package com.mine.domain.auction;
 
+import com.mine.domain.bid.HighestBid;
 import com.mine.domain.user.User;
 import lombok.Builder;
 import lombok.Getter;
@@ -28,6 +29,14 @@ public class AuctionCommand {
                 .title(this.title)
                 .startingPrice(this.startingPrice)
                 .closingTime(closingTime)
+                .build();
+    }
+
+    public HighestBid toEntity(Long auctionId) {
+        return HighestBid.builder()
+                .auction(Auction.builder().id(auctionId).build())
+                .user(User.builder().id(this.userId).build())
+                .highestPrice(this.startingPrice)
                 .build();
     }
 }

--- a/src/main/java/com/mine/domain/auction/AuctionServiceImpl.java
+++ b/src/main/java/com/mine/domain/auction/AuctionServiceImpl.java
@@ -1,5 +1,7 @@
 package com.mine.domain.auction;
 
+import com.mine.domain.bid.HighestBid;
+import com.mine.domain.bid.HighestBidStore;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -12,12 +14,19 @@ public class AuctionServiceImpl implements AuctionService {
 
     private final AuctionStore auctionStore;
     private final AuctionReader auctionReader;
+    private final HighestBidStore highestBidStore;
 
     @Override
     public AuctionInfo createAuction(AuctionCommand command) {
+        // 경매 생성
         ZonedDateTime closingTime = ZonedDateTime.now(ZoneId.of("UTC")).plusDays(command.getDuration());    // 경매 지속일을 더한 날짜/시간
         Auction initAuction = command.toEntity(closingTime);
         Auction auction = auctionStore.store(initAuction);
+
+        // 최고 입찰가를 경매 시작가로 초기화
+        HighestBid initHighestBid = command.toEntity(auction.getId());
+        highestBidStore.store(initHighestBid);
+
         return new AuctionInfo(auction);
     }
 

--- a/src/main/java/com/mine/domain/bid/BidCommand.java
+++ b/src/main/java/com/mine/domain/bid/BidCommand.java
@@ -1,0 +1,26 @@
+package com.mine.domain.bid;
+
+import com.mine.domain.auction.Auction;
+import com.mine.domain.user.User;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.ZonedDateTime;
+
+@Builder
+@Getter
+public class BidCommand {
+
+    private final long auctionId;
+    private final long userId;
+    private final long price;
+
+    public BidHistory toEntity(ZonedDateTime biddingTime) {
+        return BidHistory.builder()
+                .auction(Auction.builder().id(this.auctionId).build())
+                .user(User.builder().id(this.userId).build())
+                .biddingPrice(this.price)
+                .biddingTime(biddingTime)
+                .build();
+    }
+}

--- a/src/main/java/com/mine/domain/bid/BidHistory.java
+++ b/src/main/java/com/mine/domain/bid/BidHistory.java
@@ -1,0 +1,36 @@
+package com.mine.domain.bid;
+
+import com.mine.domain.auction.Auction;
+import com.mine.domain.user.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.time.ZonedDateTime;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Table(name = "bid_history")
+public class BidHistory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "auction_id")
+    private Auction auction;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    private long biddingPrice;
+
+    private ZonedDateTime biddingTime;
+}

--- a/src/main/java/com/mine/domain/bid/BidHistoryStore.java
+++ b/src/main/java/com/mine/domain/bid/BidHistoryStore.java
@@ -1,0 +1,6 @@
+package com.mine.domain.bid;
+
+public interface BidHistoryStore {
+
+    BidHistory store(BidHistory initBidHistory);
+}

--- a/src/main/java/com/mine/domain/bid/BidInfo.java
+++ b/src/main/java/com/mine/domain/bid/BidInfo.java
@@ -1,0 +1,23 @@
+package com.mine.domain.bid;
+
+import lombok.Getter;
+
+import java.time.ZonedDateTime;
+
+@Getter
+public class BidInfo {
+
+    private final long bidHistoryId;
+    private final long auctionId;
+    private final long userId;
+    private final long biddingPrice;
+    private final ZonedDateTime biddingTime;
+
+    public BidInfo(BidHistory bidHistory) {
+        this.bidHistoryId = bidHistory.getId();
+        this.auctionId = bidHistory.getAuction().getId();
+        this.userId = bidHistory.getUser().getId();
+        this.biddingPrice = bidHistory.getBiddingPrice();
+        this.biddingTime = bidHistory.getBiddingTime();
+    }
+}

--- a/src/main/java/com/mine/domain/bid/BidService.java
+++ b/src/main/java/com/mine/domain/bid/BidService.java
@@ -1,0 +1,6 @@
+package com.mine.domain.bid;
+
+public interface BidService {
+
+    BidInfo bid(BidCommand command);
+}

--- a/src/main/java/com/mine/domain/bid/BidServiceImpl.java
+++ b/src/main/java/com/mine/domain/bid/BidServiceImpl.java
@@ -1,0 +1,50 @@
+package com.mine.domain.bid;
+
+import com.mine.common.exception.AuctionAlreadyClosedException;
+import com.mine.common.exception.HighestBidPriceUpdateException;
+import com.mine.domain.user.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class BidServiceImpl implements BidService {
+
+    private final HighestBidReader highestBidReader;
+    private final HighestBidStore highestBidStore;
+    private final BidHistoryStore bidHistoryStore;
+
+    @Override
+    @Transactional
+    public BidInfo bid(BidCommand command) {
+        HighestBid currentHighestBid = highestBidReader.findByAuctionId(command.getAuctionId());
+        ZonedDateTime closingTime = currentHighestBid.getAuction().getClosingTime();
+        ZonedDateTime biddingTime = ZonedDateTime.now(ZoneId.of("UTC"));
+
+        // 마감된 경매일 경우 입찰 실패
+        if(biddingTime.isEqual(closingTime) || biddingTime.isAfter(closingTime)) {
+            throw new AuctionAlreadyClosedException();
+        }
+
+        // 최고 입찰가보다 낮은 입찰가로 입찰할 경우 입찰 실패
+        if(command.getPrice() <= currentHighestBid.getHighestPrice()) {
+            throw new HighestBidPriceUpdateException();
+        }
+
+        // 최고 입찰가 갱신
+        currentHighestBid.setUser(User.builder().id(command.getUserId()).build());
+        currentHighestBid.setHighestPrice(command.getPrice());
+        highestBidStore.store(currentHighestBid);
+
+        // 입찰 내역 반영
+        BidHistory initBidHistory = command.toEntity(biddingTime);
+        BidHistory oneHistory = bidHistoryStore.store(initBidHistory);
+
+        // 반영된 내역 반환
+        return new BidInfo(oneHistory);
+    }
+}

--- a/src/main/java/com/mine/domain/bid/HighestBid.java
+++ b/src/main/java/com/mine/domain/bid/HighestBid.java
@@ -1,0 +1,32 @@
+package com.mine.domain.bid;
+
+import com.mine.domain.auction.Auction;
+import com.mine.domain.user.User;
+import lombok.*;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Table(name = "highest_bid")
+public class HighestBid {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne
+    @JoinColumn(name = "auction_id")
+    private Auction auction;
+
+    @Setter
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Setter
+    private long highestPrice;
+}

--- a/src/main/java/com/mine/domain/bid/HighestBidReader.java
+++ b/src/main/java/com/mine/domain/bid/HighestBidReader.java
@@ -1,0 +1,6 @@
+package com.mine.domain.bid;
+
+public interface HighestBidReader {
+
+    HighestBid findByAuctionId(Long auctionId);
+}

--- a/src/main/java/com/mine/domain/bid/HighestBidStore.java
+++ b/src/main/java/com/mine/domain/bid/HighestBidStore.java
@@ -1,0 +1,6 @@
+package com.mine.domain.bid;
+
+public interface HighestBidStore {
+
+    void store(HighestBid newHighestBid);
+}

--- a/src/main/java/com/mine/infrastructure/bid/BidHistoryRepository.java
+++ b/src/main/java/com/mine/infrastructure/bid/BidHistoryRepository.java
@@ -1,0 +1,8 @@
+package com.mine.infrastructure.bid;
+
+import com.mine.domain.bid.BidHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BidHistoryRepository extends JpaRepository<BidHistory, Long> {
+
+}

--- a/src/main/java/com/mine/infrastructure/bid/BidHistoryStoreImpl.java
+++ b/src/main/java/com/mine/infrastructure/bid/BidHistoryStoreImpl.java
@@ -1,0 +1,18 @@
+package com.mine.infrastructure.bid;
+
+import com.mine.domain.bid.BidHistory;
+import com.mine.domain.bid.BidHistoryStore;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class BidHistoryStoreImpl implements BidHistoryStore {
+
+    private final BidHistoryRepository bidHistoryRepository;
+
+    @Override
+    public BidHistory store(BidHistory initBidHistory) {
+        return bidHistoryRepository.save(initBidHistory);
+    }
+}

--- a/src/main/java/com/mine/infrastructure/bid/HighestBidReaderImpl.java
+++ b/src/main/java/com/mine/infrastructure/bid/HighestBidReaderImpl.java
@@ -1,0 +1,18 @@
+package com.mine.infrastructure.bid;
+
+import com.mine.domain.bid.HighestBid;
+import com.mine.domain.bid.HighestBidReader;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class HighestBidReaderImpl implements HighestBidReader {
+
+    private final HighestBidRepository highestBidRepository;
+
+    @Override
+    public HighestBid findByAuctionId(Long auctionId) {
+        return highestBidRepository.findByAuctionId(auctionId);
+    }
+}

--- a/src/main/java/com/mine/infrastructure/bid/HighestBidRepository.java
+++ b/src/main/java/com/mine/infrastructure/bid/HighestBidRepository.java
@@ -1,0 +1,13 @@
+package com.mine.infrastructure.bid;
+
+import com.mine.domain.bid.HighestBid;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+
+import javax.persistence.LockModeType;
+
+public interface HighestBidRepository extends JpaRepository<HighestBid, Long> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    HighestBid findByAuctionId(Long auctionId);
+}

--- a/src/main/java/com/mine/infrastructure/bid/HighestBidStoreImpl.java
+++ b/src/main/java/com/mine/infrastructure/bid/HighestBidStoreImpl.java
@@ -1,0 +1,18 @@
+package com.mine.infrastructure.bid;
+
+import com.mine.domain.bid.HighestBid;
+import com.mine.domain.bid.HighestBidStore;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class HighestBidStoreImpl implements HighestBidStore {
+
+    private final HighestBidRepository highestBidRepository;
+
+    @Override
+    public void store(HighestBid newHighestBid) {
+        highestBidRepository.save(newHighestBid);
+    }
+}

--- a/src/main/java/com/mine/interfaces/bid/BidController.java
+++ b/src/main/java/com/mine/interfaces/bid/BidController.java
@@ -1,0 +1,27 @@
+package com.mine.interfaces.bid;
+
+import com.mine.application.bid.BidFacade;
+import com.mine.domain.bid.BidCommand;
+import com.mine.domain.bid.BidInfo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/bid")
+public class BidController {
+
+    private final BidFacade bidFacade;
+
+    @PostMapping
+    public ResponseEntity<BidDto.BidResponse> bid(@RequestBody BidDto.BidRequest request) {
+        BidCommand command = request.toCommand();
+        BidInfo bidInfo = bidFacade.bid(command);
+        BidDto.BidResponse response = new BidDto.BidResponse(bidInfo);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/mine/interfaces/bid/BidDto.java
+++ b/src/main/java/com/mine/interfaces/bid/BidDto.java
@@ -1,0 +1,54 @@
+package com.mine.interfaces.bid;
+
+import com.mine.domain.bid.BidCommand;
+import com.mine.domain.bid.BidInfo;
+import com.mine.util.SecurityUtil;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.FormatStyle;
+
+public class BidDto {
+
+    @Setter
+    public static class BidRequest {
+
+        private long auctionId;
+        private long price;
+
+        public BidCommand toCommand() {
+            return BidCommand.builder()
+                    .auctionId(this.auctionId)
+                    .userId(SecurityUtil.getCurrentMemberId())
+                    .price(this.price)
+                    .build();
+        }
+    }
+
+    @Getter
+    public static class BidResponse {
+
+        private final long bidHistoryId;
+        private final long auctionId;
+        private final long userId;
+        private final long biddingPrice;
+        private final String biddingTime;
+
+        public BidResponse(BidInfo bidInfo) {
+            this.bidHistoryId = bidInfo.getBidHistoryId();
+            this.auctionId = bidInfo.getAuctionId();
+            this.userId = bidInfo.getUserId();
+            this.biddingPrice = bidInfo.getBiddingPrice();
+            this.biddingTime = getLocalBiddingTime(bidInfo.getBiddingTime());
+        }
+
+        private String getLocalBiddingTime(ZonedDateTime utc) {
+            LocalDateTime time = utc.withZoneSameInstant(ZoneId.of("Asia/Seoul")).toLocalDateTime();
+            return DateTimeFormatter.ofLocalizedDateTime(FormatStyle.FULL, FormatStyle.SHORT).format(time);
+        }
+    }
+}

--- a/src/test/java/com/mine/domain/bid/BidServiceImplTest.java
+++ b/src/test/java/com/mine/domain/bid/BidServiceImplTest.java
@@ -1,0 +1,103 @@
+package com.mine.domain.bid;
+
+import com.mine.common.exception.AuctionAlreadyClosedException;
+import com.mine.common.exception.HighestBidPriceUpdateException;
+import com.mine.domain.auction.Auction;
+import com.mine.domain.user.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class BidServiceImplTest {
+
+    @Mock
+    HighestBidReader highestBidReader;
+
+    @Mock
+    HighestBidStore highestBidStore;
+
+    @Mock
+    BidHistoryStore bidHistoryStore;
+
+    @InjectMocks
+    BidServiceImpl bidService;
+
+    BidCommand command;
+
+    @BeforeEach
+    void setUp() {
+        command = BidCommand.builder()
+                .auctionId(1)
+                .userId(1)
+                .price(100000)
+                .build();
+    }
+
+    @Test
+    @DisplayName("입찰 성공")
+    void successBid() {
+        HighestBid currentHighestBid = HighestBid.builder()
+                .auction(Auction.builder().closingTime(ZonedDateTime.parse("2100-10-25T08:28:53.444790Z[UTC]")).build())
+                .highestPrice(50000)
+                .build();
+
+        BidHistory savedOneHistory = BidHistory.builder()
+                .id(1L)
+                .auction(Auction.builder().id(1L).build())
+                .user(User.builder().id(1L).build())
+                .biddingPrice(100000)
+                .biddingTime(ZonedDateTime.now(ZoneId.of("UTC")))
+                .build();
+
+        when(highestBidReader.findByAuctionId(command.getAuctionId())).thenReturn(currentHighestBid);
+        when(bidHistoryStore.store(any())).thenReturn(savedOneHistory);
+
+        BidInfo bidInfo = bidService.bid(command);
+
+        assertEquals(command.getUserId(), bidInfo.getUserId());
+        assertEquals(command.getPrice(), bidInfo.getBiddingPrice());
+    }
+
+    @Test
+    @DisplayName("마감된 경매에 입찰한 경우 입찰 실패")
+    void throwWhenClosedAuction() {
+        HighestBid currentHighestBid = HighestBid.builder()
+                .auction(Auction.builder().closingTime(ZonedDateTime.parse("2022-08-20T15:28:53.444790Z[UTC]")).build())
+                .highestPrice(50000)
+                .build();
+
+        when(highestBidReader.findByAuctionId(command.getAuctionId())).thenReturn(currentHighestBid);
+
+        AuctionAlreadyClosedException e = assertThrows(AuctionAlreadyClosedException.class, () -> bidService.bid(command));
+
+        assertEquals("이미 마감된 경매입니다. 더 이상 입찰할 수 없습니다.", e.getMessage());
+    }
+
+    @Test
+    @DisplayName("최고 입찰가보다 낮은 입찰가로 입찰한 경우 입찰 실패")
+    void throwWhenLowBiddingPrice() {
+        HighestBid currentHighestBid = HighestBid.builder()
+                .auction(Auction.builder().closingTime(ZonedDateTime.parse("2100-10-25T08:28:53.444790Z[UTC]")).build())
+                .highestPrice(500000)
+                .build();
+
+        when(highestBidReader.findByAuctionId(command.getAuctionId())).thenReturn(currentHighestBid);
+
+        HighestBidPriceUpdateException e = assertThrows(HighestBidPriceUpdateException.class, () -> bidService.bid(command));
+
+        assertEquals("입찰에 실패했습니다. 현재 최고 입찰가보다 높은 입찰가로 다시 시도해주세요.", e.getMessage());
+    }
+}


### PR DESCRIPTION
## Updates
- **수동 입찰 기능 개발**
  - 경매 ID, 입찰가가 전달되면 입찰 요청 수행
  - 반영된 입찰 내역 데이터 응답(입찰 내역 ID, 경매 ID, 사용자 ID, 입찰가, 입찰 시간)

## Description
- 입찰 성공 시 최고 입찰가가 갱신되면 입찰 내역에도 반영되어야 하고 실패 시 반영되면 안 되기 때문에 최고 입찰가 갱신, 입찰 내역 반영을 하나의 트랜잭션으로 처리
- 마감된 경매일 경우, 정의한 AuctionAlreadyClosedException 발생
- 최고 입찰가 이하로 입찰할 경우, 정의한 HighestBidPriceUpdateException 발생
- 여러 트랜잭션이 최고 입찰가 데이터에 읽기/쓰기 오퍼레이션을 수행하면서 동시성 이슈가 발생할 수 있기 때문에 최고 입찰가 테이블에서 해당 경매에 대한 Row에 Exclusive Lock 설정
- Exclusive Lock 설정 시 해당 Row에 대한 '읽기', '잠금 설정', '쓰기', '삭제'가 불가능하기 때문에 경매 카탈로그 조회 시 최고 입찰가 테이블 데이터에 접근하지 못해 카탈로그 조회가 불가능한 상황이 우려됐으나,  Inno DB의 Default Isolation Level이 Repeatable Read이기 때문에 Consistent Read가 적용되어 읽기 오퍼레이션의 경우 작업 중인 트랜잭션에서 처음 읽은 데이터의 Snapshot을 읽게 하여 Lock에 상관없이 수행 가능한 것으로 확인

## References
- https://www.baeldung.com/jpa-pessimistic-locking
- https://mariadb.com/kb/en/for-update/
- https://dev.mysql.com/doc/refman/8.0/en/innodb-transaction-isolation-levels.html#isolevel_repeatable-read
- https://dev.mysql.com/doc/refman/8.0/en/glossary.html#glos_consistent_read
- https://dev.mysql.com/doc/refman/8.0/en/innodb-consistent-read.html
- https://mariadb.com/kb/en/innodb-undo-log/