### PR TITLE
입찰가 증분 계산 기능 개발

### DIFF
--- a/src/main/java/com/mine/common/response/ErrorCode.java
+++ b/src/main/java/com/mine/common/response/ErrorCode.java
@@ -12,7 +12,7 @@ public enum ErrorCode {
     COMMON_ENTITY_NOT_FOUND("존재하지 않는 엔티티입니다."),
     COMMON_ILLEGAL_STATUS("잘못된 상태 값입니다."),
     COMMON_ENTITY_EXISTS("이미 존재하는 엔티티입니다."),
-    COMMON_HIGHEST_BID_NOT_UPDATED("입찰에 실패했습니다. 현재 최고 입찰가보다 높은 입찰가로 다시 시도해주세요."),
+    COMMON_HIGHEST_BID_NOT_UPDATED("입찰에 실패했습니다. 입찰 가능한 최소 입찰가 이상으로 다시 입찰해 주세요."),
     COMMON_AUCTION_ALREADY_CLOSED("이미 마감된 경매입니다. 더 이상 입찰할 수 없습니다.");
 
     private final String errorMessage;

--- a/src/main/java/com/mine/domain/auction/Auction.java
+++ b/src/main/java/com/mine/domain/auction/Auction.java
@@ -1,10 +1,8 @@
 package com.mine.domain.auction;
 
+import com.mine.domain.bid.HighestBid;
 import com.mine.domain.user.User;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import javax.persistence.*;
 import java.time.ZonedDateTime;
@@ -30,4 +28,8 @@ public class Auction {
     private long startingPrice;
 
     private ZonedDateTime closingTime;
+
+    @Setter
+    @OneToOne(mappedBy = "auction")
+    private HighestBid highestBid;
 }

--- a/src/main/java/com/mine/domain/auction/AuctionCommand.java
+++ b/src/main/java/com/mine/domain/auction/AuctionCommand.java
@@ -36,7 +36,7 @@ public class AuctionCommand {
         return HighestBid.builder()
                 .auction(Auction.builder().id(auctionId).build())
                 .user(User.builder().id(this.userId).build())
-                .highestPrice(this.startingPrice)
+                .atLeast(this.startingPrice)
                 .build();
     }
 }

--- a/src/main/java/com/mine/domain/auction/AuctionInfo.java
+++ b/src/main/java/com/mine/domain/auction/AuctionInfo.java
@@ -15,7 +15,10 @@ public class AuctionInfo {
     private final String title;
     private final long startingPrice;
     private final ZonedDateTime closingTime;
+    private final long highestPrice;
+    private final long atLeast;
     private final long userId;
+
     @Setter
     private List<URL> fileUrls = new ArrayList<>();
 
@@ -24,6 +27,8 @@ public class AuctionInfo {
         this.title = auction.getTitle();
         this.startingPrice = auction.getStartingPrice();
         this.closingTime = auction.getClosingTime();
+        this.highestPrice = auction.getHighestBid().getHighestPrice();
+        this.atLeast = auction.getHighestBid().getAtLeast();
         this.userId = auction.getUser().getId();
     }
 }

--- a/src/main/java/com/mine/domain/auction/AuctionServiceImpl.java
+++ b/src/main/java/com/mine/domain/auction/AuctionServiceImpl.java
@@ -23,10 +23,11 @@ public class AuctionServiceImpl implements AuctionService {
         Auction initAuction = command.toEntity(closingTime);
         Auction auction = auctionStore.store(initAuction);
 
-        // 최고 입찰가를 경매 시작가로 초기화
+        // 입찰 가능한 최소 입찰가를 경매 시작가로 초기화
         HighestBid initHighestBid = command.toEntity(auction.getId());
-        highestBidStore.store(initHighestBid);
+        HighestBid highestBid = highestBidStore.store(initHighestBid);
 
+        auction.setHighestBid(highestBid);
         return new AuctionInfo(auction);
     }
 

--- a/src/main/java/com/mine/domain/bid/HighestBid.java
+++ b/src/main/java/com/mine/domain/bid/HighestBid.java
@@ -29,4 +29,7 @@ public class HighestBid {
 
     @Setter
     private long highestPrice;
+
+    @Setter
+    private long atLeast;
 }

--- a/src/main/java/com/mine/domain/bid/HighestBidStore.java
+++ b/src/main/java/com/mine/domain/bid/HighestBidStore.java
@@ -2,5 +2,5 @@ package com.mine.domain.bid;
 
 public interface HighestBidStore {
 
-    void store(HighestBid newHighestBid);
+    HighestBid store(HighestBid newHighestBid);
 }

--- a/src/main/java/com/mine/infrastructure/bid/HighestBidStoreImpl.java
+++ b/src/main/java/com/mine/infrastructure/bid/HighestBidStoreImpl.java
@@ -12,7 +12,7 @@ public class HighestBidStoreImpl implements HighestBidStore {
     private final HighestBidRepository highestBidRepository;
 
     @Override
-    public void store(HighestBid newHighestBid) {
-        highestBidRepository.save(newHighestBid);
+    public HighestBid store(HighestBid newHighestBid) {
+        return highestBidRepository.save(newHighestBid);
     }
 }

--- a/src/main/java/com/mine/interfaces/auction/AuctionDto.java
+++ b/src/main/java/com/mine/interfaces/auction/AuctionDto.java
@@ -54,6 +54,8 @@ public class AuctionDto {
         private final long startingPrice;
         private final String closingTime;
         private final ZonedDateTime utc;
+        private final long highestPrice;
+        private final long atLeast;
         private final long userId;
 
         public CreateAuctionResponse(AuctionInfo auctionInfo) {
@@ -62,6 +64,8 @@ public class AuctionDto {
             this.startingPrice = auctionInfo.getStartingPrice();
             this.closingTime = getLocalClosingTime(auctionInfo.getClosingTime());
             this.utc = auctionInfo.getClosingTime();
+            this.highestPrice = auctionInfo.getHighestPrice();
+            this.atLeast = auctionInfo.getAtLeast();
             this.userId = auctionInfo.getUserId();
         }
 
@@ -78,6 +82,8 @@ public class AuctionDto {
         private final String title;
         private final Long startingPrice;
         private final String closingTime;
+        private final long highestPrice;
+        private final long atLeast;
         private final Long userId;
         private final List<URL> fileUrls;
 
@@ -86,6 +92,8 @@ public class AuctionDto {
             this.title = auctionInfo.getTitle();
             this.startingPrice = auctionInfo.getStartingPrice();
             this.closingTime = getLocalClosingTime(auctionInfo.getClosingTime());
+            this.highestPrice = auctionInfo.getHighestPrice();
+            this.atLeast = auctionInfo.getAtLeast();
             this.userId = auctionInfo.getUserId();
             this.fileUrls = new ArrayList<>(auctionInfo.getFileUrls());
         }

--- a/src/main/java/com/mine/util/IncrementUtil.java
+++ b/src/main/java/com/mine/util/IncrementUtil.java
@@ -1,0 +1,34 @@
+package com.mine.util;
+
+public class IncrementUtil {
+
+    private IncrementUtil() {
+
+    }
+
+    public static int getIncrement(long price) {
+        int increment = 0;
+
+        if (price < 10000) {
+            increment = 500;
+        } else if (price < 50000) {
+            increment = 800;
+        } else if (price < 150000) {
+            increment = 2000;
+        } else if (price < 350000) {
+            increment = 4000;
+        } else if (price < 700000) {
+            increment = 7500;
+        } else if (price < 1350000) {
+            increment = 15000;
+        } else if (price < 3500000) {
+            increment = 38000;
+        } else if (price < 7000000) {
+            increment = 75000;
+        } else {
+            increment = 150000;
+        }
+
+        return increment;
+    }
+}

--- a/src/test/java/com/mine/domain/auction/AuctionServiceImplTest.java
+++ b/src/test/java/com/mine/domain/auction/AuctionServiceImplTest.java
@@ -23,6 +23,9 @@ public class AuctionServiceImplTest {
     AuctionStore auctionStore;
 
     @Mock
+    AuctionReader auctionReader;
+
+    @Mock
     HighestBidStore highestBidStore;
 
     @InjectMocks
@@ -53,6 +56,7 @@ public class AuctionServiceImplTest {
         assertEquals(savedAuction.getId(), auctionInfo.getId());
     }
 
+    @Test
     @DisplayName("경매 카탈로그 조회")
     void showCatalog() {
         Auction readAuction = Auction.builder()
@@ -60,8 +64,10 @@ public class AuctionServiceImplTest {
                 .user(User.builder().id(1L).build())
                 .title("New Auction")
                 .startingPrice(50000L)
-                .closingTime(ZonedDateTime.parse("2022-08-12 12:37:09"))
+                .closingTime(ZonedDateTime.parse("2022-08-20T15:28:53.444790Z[UTC]"))
                 .build();
+
+        when(auctionReader.read(1L)).thenReturn(readAuction);
 
         AuctionInfo auctionInfo = auctionService.showCatalog(1L);
 

--- a/src/test/java/com/mine/domain/auction/AuctionServiceImplTest.java
+++ b/src/test/java/com/mine/domain/auction/AuctionServiceImplTest.java
@@ -1,5 +1,6 @@
 package com.mine.domain.auction;
 
+import com.mine.domain.bid.HighestBidStore;
 import com.mine.domain.user.User;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -20,6 +21,9 @@ public class AuctionServiceImplTest {
 
     @Mock
     AuctionStore auctionStore;
+
+    @Mock
+    HighestBidStore highestBidStore;
 
     @InjectMocks
     AuctionServiceImpl auctionService;

--- a/src/test/java/com/mine/domain/bid/BidServiceImplTest.java
+++ b/src/test/java/com/mine/domain/bid/BidServiceImplTest.java
@@ -52,6 +52,7 @@ public class BidServiceImplTest {
         HighestBid currentHighestBid = HighestBid.builder()
                 .auction(Auction.builder().closingTime(ZonedDateTime.parse("2100-10-25T08:28:53.444790Z[UTC]")).build())
                 .highestPrice(50000)
+                .atLeast(52000)
                 .build();
 
         BidHistory savedOneHistory = BidHistory.builder()
@@ -77,6 +78,7 @@ public class BidServiceImplTest {
         HighestBid currentHighestBid = HighestBid.builder()
                 .auction(Auction.builder().closingTime(ZonedDateTime.parse("2022-08-20T15:28:53.444790Z[UTC]")).build())
                 .highestPrice(50000)
+                .atLeast(52000)
                 .build();
 
         when(highestBidReader.findByAuctionId(command.getAuctionId())).thenReturn(currentHighestBid);
@@ -87,17 +89,18 @@ public class BidServiceImplTest {
     }
 
     @Test
-    @DisplayName("최고 입찰가보다 낮은 입찰가로 입찰한 경우 입찰 실패")
+    @DisplayName("입찰 가능한 최소 입찰가 미만으로 입찰한 경우 입찰 실패")
     void throwWhenLowBiddingPrice() {
         HighestBid currentHighestBid = HighestBid.builder()
                 .auction(Auction.builder().closingTime(ZonedDateTime.parse("2100-10-25T08:28:53.444790Z[UTC]")).build())
                 .highestPrice(500000)
+                .atLeast(507500)
                 .build();
 
         when(highestBidReader.findByAuctionId(command.getAuctionId())).thenReturn(currentHighestBid);
 
         HighestBidPriceUpdateException e = assertThrows(HighestBidPriceUpdateException.class, () -> bidService.bid(command));
 
-        assertEquals("입찰에 실패했습니다. 현재 최고 입찰가보다 높은 입찰가로 다시 시도해주세요.", e.getMessage());
+        assertEquals("입찰에 실패했습니다. 입찰 가능한 최소 입찰가 이상으로 다시 입찰해 주세요.", e.getMessage());
     }
 }


### PR DESCRIPTION
## Updates
- **입찰가 증분 계산 기능 개발**
  - 입찰 요청이 성공적으로 수행될 경우, 해당 입찰가와 증분을 더한 금액 이상으로 다음 입찰이 수행될 수 있도록 증분 계산
  - 증분 계산 메서드를 static으로 선언하여 프로그램 실행 시 Method 영역에 적재, 사용 빈도가 높고 빠르게 처리돼야 할 입찰 요청을 위해 클래스 생성 없이 바로 사용 가능하도록 만듦

## Description
- 1 원 단위로 입찰이 가능할 경우, 마구잡이 식 요청으로 인해 대규모 트래픽이 발생할 수 있기 때문에 입찰가 증분이 필요하다고 판단
- JMH(Java Microbenchmark Harness)를 사용한 벤치마크 결과를 기반으로, 증분 계산을 위해 고안한 다섯 가지 방법 중 if 문 사용
- 퍼센트 계산이 가장 좋은 성능을 보이지만 입찰가가 높아질수록 필요 이상으로 증분이 커지기 때문에 적정 증분을 구할 수 없다고 판단하여 사용하지 않음

<img width="396" alt="스크린샷 2022-09-12 오전 12 36 49" src="https://user-images.githubusercontent.com/76784643/191800643-4f23944d-c91e-455e-b5ac-f5e67a540971.png">

Method | Description
---- | ----
MyBenchmark.first | if
MyBenchmark.second | 입찰가 자릿수 계산(상용 로그 사용) + switch
MyBenchmark.third | 입찰가 자릿수 계산(상용 로그 사용) + hash map
MyBenchmark.fourth | tree map(red black tree)
MyBenchmark.fifth | 입찰가의 3.5%